### PR TITLE
Implement other built-in methods

### DIFF
--- a/backend/backend/Services/Lua/LuaScriptRunner.cs
+++ b/backend/backend/Services/Lua/LuaScriptRunner.cs
@@ -6,7 +6,7 @@ namespace backend.Services.Lua;
 
 public class LuaScriptRunner : ILuaScriptRunner
 {
-    private readonly Script _script = new Script(CoreModules.None);
+    private readonly Script _script = new Script(CoreModules.Preset_SoftSandbox);
     private DistrictDetails? _districtDetails;
     public SimulationData SimulationData { get; set; }
     public string? Code { get; set; }

--- a/backend/backend/Services/Lua/LuaService.cs
+++ b/backend/backend/Services/Lua/LuaService.cs
@@ -8,8 +8,48 @@ using MoonSharp.Interpreter;
 
 public class LuaService : IMethodService
 {
-    //TODO
-    private const string DhondtMethod = "";
+    private const string DhondtMethod = @"
+local coalitionThreshold = 0.08
+local lowerThreshold = 0.05
+local passesThreshold = {}
+for i = 1, TotalParties() do
+    if not NeedsThreshold(i) then
+        passesThreshold[i] = true
+    else
+        local percentage = NationalPartyVotes(i) / NationalTotalVotes()
+        if IsCoalition(i) then
+            passesThreshold[i] = percentage >= coalitionThreshold
+        else
+            passesThreshold[i] = percentage >= lowerThreshold
+        end
+    end
+end
+
+local quotients = {}
+for i = 1, TotalParties() do
+    if passesThreshold[i] then
+        for d = 1, DistrictSeats() do
+            table.insert(quotients, { party = i, quotient = DistrictPartyVotes(i) / d })
+        end
+    end
+end
+
+local function compareQuotients(a, b)
+    return a.quotient > b.quotient
+end
+
+table.sort(quotients, compareQuotients)
+local t = {}
+for i = 1, TotalParties() do
+    t[i] = 0
+end
+for i = 1, DistrictSeats() do
+    local index = quotients[i].party
+    t[index] = t[index] + 1
+end
+
+return t
+";
     private const string HighStakesMethod = @"
 local winningParty = 1
 local maxVotes = DistrictPartyVotes(1)
@@ -25,8 +65,48 @@ for i = 1, TotalParties() do
 end
 return t
 ";
-    //TODO
-    private const string SainteLagueMethod = "";
+    private const string SainteLagueMethod = @"
+local coalitionThreshold = 0.08
+local lowerThreshold = 0.05
+local passesThreshold = {}
+for i = 1, TotalParties() do
+    if not NeedsThreshold(i) then
+        passesThreshold[i] = true
+    else
+        local percentage = NationalPartyVotes(i) / NationalTotalVotes()
+        if IsCoalition(i) then
+            passesThreshold[i] = percentage >= coalitionThreshold
+        else
+            passesThreshold[i] = percentage >= lowerThreshold
+        end
+    end
+end
+
+local quotients = {}
+for i = 1, TotalParties() do
+    if passesThreshold[i] then
+        for d = 0, DistrictSeats() - 1 do
+            table.insert(quotients, { party = i, quotient = DistrictPartyVotes(i) / (d + 0.5) })
+        end
+    end
+end
+
+local function compareQuotients(a, b)
+    return a.quotient > b.quotient
+end
+
+table.sort(quotients, compareQuotients)
+local t = {}
+for i = 1, TotalParties() do
+    t[i] = 0
+end
+for i = 1, DistrictSeats() do
+    local index = quotients[i].party
+    t[index] = t[index] + 1
+end
+
+return t
+";
 
     private ILuaScriptRunner _scriptRunner;
 
@@ -72,6 +152,7 @@ return t
         }
         catch (Exception ex)
         {
+            Console.WriteLine(ex.Message);
             return new LuaResult(false, null, ex.Message);
         }
     }


### PR DESCRIPTION
I added the D'Hondt and Sainte-Lague methods in Lua, I've checked that they both return proper data instead of an empty 204, I've also checked that the D'Hondt method returns data agreeing with official 2023 election results (ignoring the slight inaccuracies in the official counts for foreign votes). I haven't checked whether the `/simulation` page loads correctly since I couldn't get the frontend to connect to localhost instead of the Azure backend, but I have high hopes.