### PR TITLE
The Method Editor Awakens: Create, Load, Save, and Know Thyself

### DIFF
--- a/frontend/Polish-election-simulation/package-lock.json
+++ b/frontend/Polish-election-simulation/package-lock.json
@@ -12,11 +12,13 @@
         "@turf/bbox": "^7.3.0",
         "@turf/rewind": "^7.3.1",
         "@turf/union": "^7.3.0",
+        "ace-builds": "^1.43.6",
         "d3": "^7.9.0",
         "d3-geo": "^3.1.1",
         "d3-selection": "^3.0.0",
         "patch-package": "^8.0.1",
         "pinia": "^3.0.4",
+        "primeicons": "^7.0.0",
         "primevue": "^4.5.2",
         "vue": "^3.5.22",
         "vue-router": "^4.6.3"
@@ -70,6 +72,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1189,9 +1192,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1206,9 +1206,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1223,9 +1220,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1240,9 +1234,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,9 +1262,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1302,9 +1290,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1319,9 +1304,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1336,9 +1318,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1353,9 +1332,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1370,9 +1346,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1387,9 +1360,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1613,9 +1583,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1633,9 +1600,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1653,9 +1617,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1673,9 +1634,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2257,6 +2215,7 @@
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2578,6 +2537,12 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/ace-builds": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.44.0.tgz",
+      "integrity": "sha512-PFNMSYqFdEUkul2Ntud0HvA09AgY+F1ag0UYdpMH60wNI/qOA8cB8tlTgoALMEwIdUPJK2CjrIQ7OnbiSS/ugQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/alien-signals": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.0.6.tgz",
@@ -2668,6 +2633,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3219,6 +3185,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4110,9 +4077,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4134,9 +4098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4158,9 +4119,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4182,9 +4140,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4624,6 +4579,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/primeicons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-7.0.0.tgz",
+      "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==",
+      "license": "MIT"
+    },
     "node_modules/primevue": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.5.2.tgz",
@@ -4952,6 +4913,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5030,6 +4992,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5234,6 +5197,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.24.tgz",
       "integrity": "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.24",
         "@vue/compiler-sfc": "3.5.24",

--- a/frontend/Polish-election-simulation/package.json
+++ b/frontend/Polish-election-simulation/package.json
@@ -18,6 +18,7 @@
     "@turf/bbox": "^7.3.0",
     "@turf/rewind": "^7.3.1",
     "@turf/union": "^7.3.0",
+    "ace-builds": "^1.43.6",
     "d3": "^7.9.0",
     "d3-geo": "^3.1.1",
     "d3-selection": "^3.0.0",

--- a/frontend/Polish-election-simulation/package.json
+++ b/frontend/Polish-election-simulation/package.json
@@ -24,6 +24,7 @@
     "d3-selection": "^3.0.0",
     "patch-package": "^8.0.1",
     "pinia": "^3.0.4",
+    "primeicons": "^7.0.0",
     "primevue": "^4.5.2",
     "vue": "^3.5.22",
     "vue-router": "^4.6.3"

--- a/frontend/Polish-election-simulation/src/App.vue
+++ b/frontend/Polish-election-simulation/src/App.vue
@@ -1,6 +1,7 @@
 <template>
+  <Toast />
   <!-- Main navigation bar using PrimeVue -->
-  <Menubar :model="items" class="fixed top-0 inset-x-0 w-full flex justify-center text-base bg-[color:var(--color-background)] z-[100]">   
+  <Menubar :model="items" class="fixed top-0 inset-x-0 w-full flex justify-center text-base bg-[color:var(--color-background)] z-[100]">
     <!-- Custom rendering for each menu item -->
     <template #item="{ item, props }">
       <router-link 
@@ -34,6 +35,7 @@
 import { RouterView } from 'vue-router'
 import { computed } from 'vue'
 import Menubar from 'primevue/menubar'
+import Toast from 'primevue/toast'
 import { useAuth } from '@/auth/useAuth'
 
 type NavItem = {

--- a/frontend/Polish-election-simulation/src/App.vue
+++ b/frontend/Polish-election-simulation/src/App.vue
@@ -51,10 +51,10 @@ const items = computed<NavItem[]>(() => [
   { label: 'Home', route: '/' },
   { label: 'About', route: '/about' },
   { label: 'Election simulation', route: '/simulation' },
+  { label: 'Method editor', route: '/method_editor'},
   auth.isAuthenticated.value
     ? { label: 'Logout', route: '/logout' }
-    : { label: 'Login', route: '/login' },
-  { label: 'Method editor', route: '/method_editor' }
+    : { label: 'Login', route: '/login' }
 ])
 </script>
 

--- a/frontend/Polish-election-simulation/src/App.vue
+++ b/frontend/Polish-election-simulation/src/App.vue
@@ -51,7 +51,8 @@ const items = computed<NavItem[]>(() => [
   { label: 'Election simulation', route: '/simulation' },
   auth.isAuthenticated.value
     ? { label: 'Logout', route: '/logout' }
-    : { label: 'Login', route: '/login' }
+    : { label: 'Login', route: '/login' },
+  { label: 'Method editor', route: '/method_editor' }
 ])
 </script>
 

--- a/frontend/Polish-election-simulation/src/api/ApportionmentMethodDetails.ts
+++ b/frontend/Polish-election-simulation/src/api/ApportionmentMethodDetails.ts
@@ -1,0 +1,5 @@
+export default interface ApportionmentMethodDetails {
+    id: string;
+    name: string;
+    luaCode: string;
+}

--- a/frontend/Polish-election-simulation/src/api/apiClient.ts
+++ b/frontend/Polish-election-simulation/src/api/apiClient.ts
@@ -2,6 +2,7 @@ import VotesID from "./VotesID.ts";
 import ResultsTableRow from "@/api/ResultsTableRow.ts";
 import get_color_for_index from "@/api/get_color_for_index.ts";
 import type ApportionmentMethod from "@/api/ApportionmentMethod.ts";
+import type ApportionmentMethodDetails from "@/api/ApportionmentMethodDetails.ts";
 import { buildBackendUrl } from "@/api/buildBackendUrl.ts";
 import { authFetch } from "@/auth/useAuth.ts";
 import DetailedResultsRow from "@/api/DetailedResultsRow.ts";
@@ -47,6 +48,36 @@ export default class apiClient {
   public static async getApportionmentMethodIDs(): Promise<ApportionmentMethod[]> {
     const data_response = await apiClient.authenticatedGet("/api/methods/Method/get-list");
     return await data_response.json();
+  }
+
+  public static async getApportionmentMethodDetails(guid: string): Promise<ApportionmentMethodDetails> {
+    const data_response = await apiClient.authenticatedGet(`/api/methods/Method/details/${guid}`);
+    return await data_response.json();
+  }
+
+  public static async deleteApportionmentMethod(guid: string): Promise<void> {
+    const response = await authFetch(buildBackendUrl(`/api/methods/Method/delete/${guid}`), {
+      method: "DELETE",
+      headers: {
+        accept: "application/json",
+      },
+    });
+
+    await apiClient.ensureSuccess(response);
+  }
+
+  public static async updateApportionmentMethod(details: ApportionmentMethodDetails): Promise<ApportionmentMethodDetails> {
+    const response = await authFetch(buildBackendUrl(`/api/methods/Method/update/${details.id}`), {
+      method: "PUT",
+      headers: {
+        accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(details),
+    });
+
+    await apiClient.ensureSuccess(response);
+    return await response.json();
   }
 
   public static async getVotesIDs(): Promise<VotesID[]> {

--- a/frontend/Polish-election-simulation/src/api/apiClient.ts
+++ b/frontend/Polish-election-simulation/src/api/apiClient.ts
@@ -66,6 +66,23 @@ export default class apiClient {
     await apiClient.ensureSuccess(response);
   }
 
+  public static async createApportionmentMethod(label: string, luaCode: string): Promise<ApportionmentMethodDetails> {
+    const response = await authFetch(
+      buildBackendUrl(`/api/methods/Method/create?${new URLSearchParams({ label })}`),
+      {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ luaCode }),
+      }
+    );
+
+    await apiClient.ensureSuccess(response);
+    return await response.json();
+  }
+
   public static async updateApportionmentMethod(details: ApportionmentMethodDetails): Promise<ApportionmentMethodDetails> {
     const response = await authFetch(buildBackendUrl(`/api/methods/Method/update/${details.id}`), {
       method: "PUT",

--- a/frontend/Polish-election-simulation/src/api/apiClient.ts
+++ b/frontend/Polish-election-simulation/src/api/apiClient.ts
@@ -83,18 +83,16 @@ export default class apiClient {
     return await response.json();
   }
 
-  public static async updateApportionmentMethod(details: ApportionmentMethodDetails): Promise<ApportionmentMethodDetails> {
+  public static async updateApportionmentMethod(details: ApportionmentMethodDetails): Promise<void> {
     const response = await authFetch(buildBackendUrl(`/api/methods/Method/update/${details.id}`), {
       method: "PUT",
       headers: {
-        accept: "application/json",
         "Content-Type": "application/json",
       },
       body: JSON.stringify(details),
     });
 
     await apiClient.ensureSuccess(response);
-    return await response.json();
   }
 
   public static async getVotesIDs(): Promise<VotesID[]> {

--- a/frontend/Polish-election-simulation/src/main.ts
+++ b/frontend/Polish-election-simulation/src/main.ts
@@ -1,4 +1,5 @@
 import './assets/main.css';
+import 'primeicons/primeicons.css';
 
 import { createApp } from 'vue';
 import App from './App.vue';

--- a/frontend/Polish-election-simulation/src/main.ts
+++ b/frontend/Polish-election-simulation/src/main.ts
@@ -6,6 +6,7 @@ import router from './router';
 import { createPinia } from 'pinia';
 
 import PrimeVue from 'primevue/config';
+import ToastService from 'primevue/toastservice';
 import Aura from '@primeuix/themes/aura';
 
 const app = createApp(App);
@@ -17,6 +18,7 @@ app.use(PrimeVue, {
         }
     }
 });
+app.use(ToastService);
 app.use(router);
 
 const pinia = createPinia();

--- a/frontend/Polish-election-simulation/src/router/index.ts
+++ b/frontend/Polish-election-simulation/src/router/index.ts
@@ -46,6 +46,14 @@ const router = createRouter({
         return { name: 'login' }
       },
     },
+    {
+      path: '/method_editor',
+      name: 'method_editor',
+      component: () => import('../views/MethodEditorView.vue'),
+      meta: {
+        requiresAuth: true,
+      },
+    }
   ],
 })
 

--- a/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
+++ b/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="toolbar">
+    <div class="left">
+      <InputSwitch v-model="vimMode" @change="applyMode" />
+      <span>VIM mode</span>
+
+      <Dropdown
+        v-model="selectedMethod"
+        :options="methods"
+        placeholder="Select method"
+        class="dropdown"
+        @change="onMethodChange"
+      />
+    </div>
+
+    <Button label="Save" icon="pi pi-save" @click="saveFile" />
+  </div>
+
+  <div ref="editor" id="editor"></div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from "vue";
+import ace from "ace-builds";
+
+// PrimeVue components (auto-registered or imported colally depending on the setup)
+import Button from "primevue/button";
+import Dropdown from "primevue/dropdown";
+import InputSwitch from "primevue/inputswitch";
+
+// Ace editor setup
+import "ace-builds/src-noconflict/mode-lua";
+import "ace-builds/src-noconflict/theme-github";
+import "ace-builds/src-noconflict/keybinding-vim";
+
+const editor = ref(null);
+let aceInstance = null;
+
+const vimMode = ref(localStorage.getItem("vimMode") === "true");
+
+// PrimeVue state
+const selectedMethod = ref(null);
+const methods = ref([
+  // ENTRY POINT: cargar métodos dinámicamente aquí
+  // { label: "Method 1", value: "method1" }
+]);
+
+onMounted(() => {
+  aceInstance = ace.edit(editor.value);
+
+  aceInstance.setTheme("ace/theme/github");
+  aceInstance.session.setMode("ace/mode/lua");
+  aceInstance.setShowPrintMargin(false);
+
+  // ENTRY POINT:
+  // fetch / load methods aquí si quieres
+  aceInstance.setValue(`function hola()
+  print("Hola mundo")
+end`, -1);
+
+  applyMode();
+
+});
+
+function applyMode() {
+  localStorage.setItem("vimMode", vimMode.value);
+
+  aceInstance.setKeyboardHandler(
+    vimMode.value ? "ace/keyboard/vim" : null
+  );
+}
+
+function onMethodChange() {
+  // ENTRY POINT: lógica de selección de método
+  console.log("Method:", selectedMethod.value);
+}
+
+function saveFile() {
+  alert("File saved");
+}
+
+onBeforeUnmount(() => {
+  if (aceInstance) {
+    aceInstance.destroy();
+    aceInstance = null;
+  }
+});
+</script>
+
+<style>
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#editor {
+  height: 300px;
+  width: 100%;
+  border-radius: 15px;
+  border: 1px solid var(--color-border);
+}
+</style>

--- a/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
+++ b/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
@@ -53,7 +53,7 @@ onMounted(() => {
   aceInstance.setShowPrintMargin(false);
 
   // ENTRY POINT:
-  // fetch / load methods aquí si quieres
+  // fetch / load methods
   aceInstance.setValue(`function hola()
   print("Hola mundo")
 end`, -1);
@@ -71,7 +71,7 @@ function applyMode() {
 }
 
 function onMethodChange() {
-  // ENTRY POINT: lógica de selección de método
+  // ENTRY POINT: Changing method logic
   console.log("Method:", selectedMethod.value);
 }
 

--- a/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
+++ b/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
@@ -114,6 +114,7 @@
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount } from "vue";
+import { useToast } from "primevue/usetoast";
 import ace from "ace-builds";
 
 import Button from "primevue/button";
@@ -127,6 +128,8 @@ import "ace-builds/src-noconflict/theme-github";
 import "ace-builds/src-noconflict/keybinding-vim";
 
 import apiClient from "@/api/apiClient.ts";
+
+const toast = useToast();
 
 const editor = ref(null);
 let aceInstance = null;
@@ -147,6 +150,7 @@ onMounted(async () => {
   aceInstance.setTheme("ace/theme/github");
   aceInstance.session.setMode("ace/mode/lua");
   aceInstance.setShowPrintMargin(false);
+  aceInstance.setOption("useWorker", false);
   aceInstance.setValue("", -1);
   applyMode();
 
@@ -172,6 +176,14 @@ async function saveFile() {
       name: currentMethodName.value,
       luaCode: aceInstance.getValue(),
     });
+    toast.add({ severity: "success", summary: "Saved", life: 3000 });
+  } catch (err) {
+    let detail = String(err instanceof Error ? err.message : err);
+    try {
+      const parsed = JSON.parse(detail);
+      if (parsed.detail) detail = parsed.detail;
+    } catch { /* not JSON */ }
+    toast.add({ severity: "error", summary: "Save failed", detail, life: 5000 });
   } finally {
     saving.value = false;
   }

--- a/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
+++ b/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
@@ -7,76 +7,114 @@
       <Dropdown
         v-model="selectedMethod"
         :options="methods"
+        optionLabel="name"
+        optionValue="id"
         placeholder="Select method"
         class="dropdown"
         @change="onMethodChange"
       />
     </div>
 
-    <Button label="Save" icon="pi pi-save" @click="saveFile" />
+    <div class="right">
+      <Button label="New" icon="pi pi-plus" severity="secondary" @click="showNewMethodDialog = true" />
+      <Button label="Save" icon="pi pi-save" :loading="saving" :disabled="!selectedMethod" @click="saveFile" />
+    </div>
   </div>
 
   <div ref="editor" id="editor"></div>
+
+  <Dialog v-model:visible="showNewMethodDialog" header="New Method" modal :style="{ width: '25rem' }">
+    <div class="dialog-body">
+      <label for="method-name">Method name</label>
+      <InputText id="method-name" v-model="newMethodName" placeholder="Enter method name" autofocus />
+    </div>
+    <template #footer>
+      <Button label="Cancel" severity="secondary" @click="showNewMethodDialog = false" />
+      <Button label="Create" icon="pi pi-check" :loading="creating" @click="createMethod" />
+    </template>
+  </Dialog>
 </template>
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount } from "vue";
 import ace from "ace-builds";
 
-// PrimeVue components (auto-registered or imported colally depending on the setup)
 import Button from "primevue/button";
+import Dialog from "primevue/dialog";
 import Dropdown from "primevue/dropdown";
 import InputSwitch from "primevue/inputswitch";
+import InputText from "primevue/inputtext";
 
-// Ace editor setup
 import "ace-builds/src-noconflict/mode-lua";
 import "ace-builds/src-noconflict/theme-github";
 import "ace-builds/src-noconflict/keybinding-vim";
+
+import apiClient from "@/api/apiClient.ts";
 
 const editor = ref(null);
 let aceInstance = null;
 
 const vimMode = ref(localStorage.getItem("vimMode") === "true");
 
-// PrimeVue state
 const selectedMethod = ref(null);
-const methods = ref([
-  // ENTRY POINT: cargar métodos dinámicamente aquí
-  // { label: "Method 1", value: "method1" }
-]);
+const currentMethodName = ref("");
+const methods = ref([]);
 
-onMounted(() => {
+const showNewMethodDialog = ref(false);
+const newMethodName = ref("");
+const creating = ref(false);
+const saving = ref(false);
+
+onMounted(async () => {
   aceInstance = ace.edit(editor.value);
-
   aceInstance.setTheme("ace/theme/github");
   aceInstance.session.setMode("ace/mode/lua");
   aceInstance.setShowPrintMargin(false);
-
-  // ENTRY POINT:
-  // fetch / load methods
-  aceInstance.setValue(`function hola()
-  print("Hola mundo")
-end`, -1);
-
+  aceInstance.setValue("", -1);
   applyMode();
 
+  methods.value = await apiClient.getApportionmentMethodIDs();
 });
 
 function applyMode() {
   localStorage.setItem("vimMode", vimMode.value);
-
-  aceInstance.setKeyboardHandler(
-    vimMode.value ? "ace/keyboard/vim" : null
-  );
+  aceInstance.setKeyboardHandler(vimMode.value ? "ace/keyboard/vim" : null);
 }
 
-function onMethodChange() {
-  // ENTRY POINT: Changing method logic
-  console.log("Method:", selectedMethod.value);
+async function onMethodChange() {
+  const details = await apiClient.getApportionmentMethodDetails(selectedMethod.value);
+  currentMethodName.value = details.name;
+  aceInstance.setValue(details.luaCode, -1);
 }
 
-function saveFile() {
-  alert("File saved");
+async function saveFile() {
+  saving.value = true;
+  try {
+    await apiClient.updateApportionmentMethod({
+      id: selectedMethod.value,
+      name: currentMethodName.value,
+      luaCode: aceInstance.getValue(),
+    });
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function createMethod() {
+  const label = newMethodName.value.trim();
+  if (!label) return;
+
+  creating.value = true;
+  try {
+    const created = await apiClient.createApportionmentMethod(label, aceInstance.getValue());
+    methods.value = await apiClient.getApportionmentMethodIDs();
+    selectedMethod.value = created.id;
+    currentMethodName.value = created.name;
+    showNewMethodDialog.value = false;
+    newMethodName.value = "";
+  } finally {
+    creating.value = false;
+  }
 }
 
 onBeforeUnmount(() => {
@@ -100,6 +138,19 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-bottom: 1rem;
 }
 
 #editor {

--- a/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
+++ b/frontend/Polish-election-simulation/src/views/MethodEditorView.vue
@@ -23,6 +23,83 @@
 
   <div ref="editor" id="editor"></div>
 
+  <div class="api-docs">
+    <h3>Scripting API</h3>
+    <p>
+      The script is invoked once per electoral district. It must return a Lua table <code>t</code>
+      indexed <code>1..TotalParties()</code> where <code>t[i]</code> is the number of seats awarded
+      to party <code>i</code> in the district. The values must sum to <code>DistrictSeats()</code>.
+    </p>
+
+    <h4>Available functions</h4>
+    <table class="api-table">
+      <thead>
+        <tr><th>Function</th><th>Returns</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>TotalParties()</code></td>
+          <td>number</td>
+          <td>Total number of parties in the election.</td>
+        </tr>
+        <tr>
+          <td><code>DistrictSeats()</code></td>
+          <td>number</td>
+          <td>Number of seats to be filled in the current district.</td>
+        </tr>
+        <tr>
+          <td><code>DistrictPartyVotes(i)</code></td>
+          <td>number</td>
+          <td>Votes cast for party <code>i</code> in the current district.</td>
+        </tr>
+        <tr>
+          <td><code>NationalPartyVotes(i)</code></td>
+          <td>number</td>
+          <td>Total votes cast for party <code>i</code> across all districts (used for threshold checks).</td>
+        </tr>
+        <tr>
+          <td><code>NationalTotalVotes()</code></td>
+          <td>number</td>
+          <td>Total votes cast across all parties and all districts.</td>
+        </tr>
+        <tr>
+          <td><code>NeedsThreshold(i)</code></td>
+          <td>boolean</td>
+          <td>
+            Returns <code>true</code> if party <code>i</code> must clear an electoral threshold to
+            receive seats. Some parties (e.g. ethnic minority lists) are exempt and always return
+            <code>false</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>IsCoalition(i)</code></td>
+          <td>boolean</td>
+          <td>
+            Returns <code>true</code> if party <code>i</code> is an electoral coalition. Coalitions
+            are typically held to a higher threshold than single parties.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h4>Conventions</h4>
+    <ul>
+      <li>Party indices are 1-based (<code>1..TotalParties()</code>).</li>
+      <li>
+        Threshold checks should use <code>NationalPartyVotes(i) / NationalTotalVotes()</code> and
+        respect both <code>NeedsThreshold(i)</code> and <code>IsCoalition(i)</code>.
+      </li>
+      <li>
+        Parties that do not pass the threshold should receive 0 seats and must still appear in the
+        returned table.
+      </li>
+      <li>
+        The script has no access to results from other districts; each district is computed
+        independently.
+      </li>
+    </ul>
+  </div>
+
   <Dialog v-model:visible="showNewMethodDialog" header="New Method" modal :style="{ width: '25rem' }">
     <div class="dialog-body">
       <label for="method-name">Method name</label>
@@ -158,5 +235,55 @@ onBeforeUnmount(() => {
   width: 100%;
   border-radius: 15px;
   border: 1px solid var(--color-border);
+}
+
+.api-docs {
+  margin-top: 2rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.api-docs h3 {
+  margin: 0 0 0.5rem;
+}
+
+.api-docs h4 {
+  margin: 1.25rem 0 0.5rem;
+}
+
+.api-docs p,
+.api-docs ul {
+  margin: 0.25rem 0;
+}
+
+.api-docs ul {
+  padding-left: 1.5rem;
+}
+
+.api-docs code {
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.85em;
+  background: var(--color-background-mute, #f3f3f3);
+}
+
+.api-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.25rem;
+}
+
+.api-table th,
+.api-table td {
+  text-align: left;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.api-table th {
+  font-weight: 600;
 }
 </style>


### PR DESCRIPTION
Summary

Democracy deserves better than alert("File saved"). This PR answers the call.

- The method editor now loads real methods from the API instead of a hardcoded Spanish hello-world function
- A shiny New Method button summons a dialog, takes a name, calls the backend, and drops you straight into editing — zero friction
- The Save button actually saves — Lua code, method name, the whole thing, persisted to the server like it always should have been
- A full Scripting API reference lives at the bottom of the editor page so nobody has to guess what NeedsThreshold does at 2am before a deadline

Test plan

- [ ] Open the method editor — dropdown should populate with real methods
- [ ] Select a method — editor should load its Lua code
- [ ] Edit the code and hit Save — changes should persist across page reloads
- [ ] Click New, enter a name, click Create — new method appears in the dropdown and is immediately selected
- [ ] Save button is disabled when no method is selected
- [ ] Scroll to the bottom — API reference table is there and legible